### PR TITLE
feat(TextProcessing): add ability to defer text processing

### DIFF
--- a/Runtime/Prefabs/Visuals.Tooltip.prefab
+++ b/Runtime/Prefabs/Visuals.Tooltip.prefab
@@ -419,7 +419,7 @@ GameObject:
   - component: {fileID: 367273391513093873}
   - component: {fileID: 367273391513093774}
   m_Layer: 0
-  m_Name: Tooltip
+  m_Name: Visuals.Tooltip
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -472,6 +472,7 @@ GameObject:
   - component: {fileID: 367273391515739106}
   - component: {fileID: 367273391515739107}
   - component: {fileID: 367273391515739109}
+  - component: {fileID: 7862108968890610043}
   m_Layer: 0
   m_Name: Internal
   m_TagString: Untagged
@@ -511,7 +512,7 @@ MonoBehaviour:
   facade: {fileID: 367273391513093774}
   lineRenderer: {fileID: 367273390916758301}
   tooltipLineAnchor: {fileID: 367273392079049769}
-  tooltipText: {fileID: 367273391068485716}
+  tooltipText: {fileID: 7862108968890610043}
   outerImage: {fileID: 367273391356633658}
   innerImage: {fileID: 367273391561714906}
 --- !u!114 &367273391515739109
@@ -530,6 +531,19 @@ MonoBehaviour:
     field: {fileID: 367273391515739107}
   onlyProcessOnActiveAndEnabled: 1
   interval: 0
+--- !u!114 &7862108968890610043
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 367273391515739104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0eb3c19599f359c47bd162b76c205d6c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tooltipText: {fileID: 367273391068485716}
 --- !u!1 &367273391561714907
 GameObject:
   m_ObjectHideFlags: 0
@@ -647,6 +661,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 15a9c53f0e146454cb669c38817bd5b7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Zinnia.Process.Moment.Collection.MomentProcessObservableList+UnityEvent,
+      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Found:
     m_PersistentCalls:
       m_Calls: []

--- a/Runtime/SharedResources/Scripts/TextProcessing.meta
+++ b/Runtime/SharedResources/Scripts/TextProcessing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fbb8b430af5c4db41a3f6729a8749279
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/TextProcessing/BaseTextProcessor.cs
+++ b/Runtime/SharedResources/Scripts/TextProcessing/BaseTextProcessor.cs
@@ -1,0 +1,26 @@
+﻿namespace Tilia.Visuals.Tooltip.TextProcessing
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// A basis for text elements that can be set and processed.
+    /// </summary>
+    public abstract class BaseTextProcessor : MonoBehaviour
+    {
+        /// <summary>
+        /// Sets the text of the associated text processor.
+        /// </summary>
+        /// <param name="text">The text to set.</param>
+        public abstract void SetText(string text);
+        /// <summary>
+        /// Sets the color of the font on the associated text processor.
+        /// </summary>
+        /// <param name="color">The color to use.</param>
+        public abstract void SetColor(Color color);
+        /// <summary>
+        /// Sets the size of the font on the associated text processor.
+        /// </summary>
+        /// <param name="size">The size to use.</param>
+        public abstract void SetSize(float size);
+    }
+}

--- a/Runtime/SharedResources/Scripts/TextProcessing/BaseTextProcessor.cs.meta
+++ b/Runtime/SharedResources/Scripts/TextProcessing/BaseTextProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f542c1c3183fe7040b8fdd7490e42abb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/TextProcessing/UITextProcessor.cs
+++ b/Runtime/SharedResources/Scripts/TextProcessing/UITextProcessor.cs
@@ -1,0 +1,39 @@
+﻿namespace Tilia.Visuals.Tooltip.TextProcessing
+{
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.XmlDocumentationAttribute;
+    using UnityEngine;
+    using UnityEngine.UI;
+
+    /// <summary>
+    /// A text processor that uses the Unity UI <see cref="Text"/> element for display.
+    /// </summary>
+    public class UITextProcessor : BaseTextProcessor
+    {
+        /// <summary>
+        /// The <see cref="Text"/> to render onto the tooltip.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public Text TooltipText { get; set; }
+
+        /// <inheritdoc />
+        public override void SetColor(Color color)
+        {
+            TooltipText.color = color;
+        }
+
+        /// <inheritdoc />
+        public override void SetSize(float size)
+        {
+            RectTransform rect = TooltipText.GetComponent<RectTransform>();
+            TooltipText.fontSize = Mathf.RoundToInt(size / rect.localScale.x);
+        }
+
+        /// <inheritdoc />
+        public override void SetText(string text)
+        {
+            TooltipText.text = text;
+        }
+    }
+}

--- a/Runtime/SharedResources/Scripts/TextProcessing/UITextProcessor.cs.meta
+++ b/Runtime/SharedResources/Scripts/TextProcessing/UITextProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0eb3c19599f359c47bd162b76c205d6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/TooltipConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/TooltipConfigurator.cs
@@ -2,6 +2,7 @@
 {
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
+    using Tilia.Visuals.Tooltip.TextProcessing;
     using UnityEngine;
     using UnityEngine.UI;
     using Zinnia.Data.Attribute;
@@ -40,7 +41,7 @@
         /// </summary>
         [Serialized]
         [field: DocumentedByXml, Restricted]
-        public Text TooltipText { get; protected set; }
+        public BaseTextProcessor TooltipText { get; protected set; }
         /// <summary>
         /// The <see cref="Image"/> to render as the tooltip outer background.
         /// </summary>
@@ -94,10 +95,9 @@
         /// </summary>
         public virtual void ConfigureText()
         {
-            RectTransform rect = TooltipText.GetComponent<RectTransform>();
-            TooltipText.text = Facade.TooltipText;
-            TooltipText.fontSize = Mathf.RoundToInt(Facade.FontSize / rect.localScale.x);
-            TooltipText.color = Facade.FontColor;
+            TooltipText.SetColor(Facade.FontColor);
+            TooltipText.SetSize(Facade.FontSize);
+            TooltipText.SetText(Facade.TooltipText);
         }
 
         /// <summary>


### PR DESCRIPTION
The new TextProcessor concept allows the text processing to be deferred
to a Text Processor type. The Unity UI Text type is provided by default
as it is the current functionality. But it would now be possible and
trivial to make a Text Processor for TextMeshPro that could then be
used on the tooltip without needing to include TextMeshPro with this
repo.