### PR TITLE
fix(Facade): make tooltip text a multi line text area

### DIFF
--- a/Runtime/SharedResources/Scripts/TooltipFacade.cs
+++ b/Runtime/SharedResources/Scripts/TooltipFacade.cs
@@ -32,7 +32,7 @@
         /// The text to display on the tooltip.
         /// </summary>
         [Serialized]
-        [field: Header("Text Settings"), DocumentedByXml]
+        [field: Header("Text Settings"), DocumentedByXml, TextArea]
         public string TooltipText { get; set; } = "Tooltip Text";
         /// <summary>
         /// The font size for the text of the tooltip.


### PR DESCRIPTION
The underlying UI text component can take a multiline string
but the Facade `ToolTip Text` property was only a single line
string making it not possible to add multiple lines via the
facade. This has been fixed by adding the `TextArea` attribute to
the property.